### PR TITLE
Truncate tables extension hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ DNADesign\Populate\Populate:
     - 'app/fixtures/populate.yml'
 ```
 
-`truncate_classes`:  An array of ClassName's whose instances are to be removed from the database prior to importing. Useful to prevent multiple copies of populated content from being imported. You should truncate any objects you create. (Supports Fleunt and Versioned objects)
+`truncate_objects`:  An array of ClassName's whose instances are to be removed from the database prior to importing. Useful to prevent multiple copies of populated content from being imported. You should truncate any objects you create. (Supports Fleunt and Versioned objects)
 
 Example:
 ```yaml
 DNADesign\Populate\Populate:
-  truncate_classes:
+  truncate_objects:
     - SilverStripe\Assets\Image
 ```
 


### PR DESCRIPTION
I liked the "clean up" stuff @adrhumphreys had done in https://github.com/adrhumphreys/silverstripe-populate/tree/feat/fluenty, but we wanted it to be backwards compatible, and not be too concerned with specifically which additional considerations are needed for truncating ahead of a Populate run.

Instead of baking fluent support straight in, I tweaked this fork/branch so that the fluent support could be added via an extension. The tweak is in the PR, and an example extension looks like this:
```
<?php

namespace Vendor\App\Extensions;

use DNADesign\Populate\Populate;
use SilverStripe\Core\Injector\Injector;
use SilverStripe\ORM\DataExtension;
use SilverStripe\ORM\DataObject;
use SilverStripe\Versioned\Versioned;
use TractorCow\Fluent\Extension\FluentExtension;

/**
 * Add greater support to {@see Populate}
 *
 * @property Populate $owner
 */
class PopulateExtension extends DataExtension
{

    /**
     * @param array $tables
     * @param string $className
     * @param array $classTables e.g ['Class\Name' => 'Table']
     */
    public function updateTruncateObjectTables(&$tables, &$className, &$classTables)
    {
        foreach ($classTables as $className => $baseTable) {
            /** @var DataObject|Versioned|FluentExtension $obj */
            $obj = Injector::inst()->get($className);

            if (!$obj->hasExtension(FluentExtension::class)) {
                // No localised tables to clear
                continue;
            }

            $fluentTable = $obj->getLocalisedTable($baseTable);

            $tables[$fluentTable] = $fluentTable;

            if (!$obj->hasExtension(Versioned::class)) {
                // No localised versioned tables to clear
                continue;
            }

            $stages = $obj->getVersionedStages();

            foreach ($stages as $stage) {
                $table = $obj->stageTable($fluentTable, $stage);

                // Include localised base and live table
                $tables[$table] = $table;
            }

            $versionedTable = "{$fluentTable}_Versions";

            // Include localised versions table
            $tables[$versionedTable] = $versionedTable;
        }
    }
}

```